### PR TITLE
removed unnecessary package, timezone added to tests config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "j20/php-uuid": "dev-master",
         "endroid/qr-code": "^1.9.3",
         "spomky-labs/base64url": "^1.0.1",
         "evenement/evenement": "1.0.*"

--- a/tests/ZoiTest.php
+++ b/tests/ZoiTest.php
@@ -2,7 +2,7 @@
 
 class ZoiTest extends \PHPUnit_Framework_TestCase
 {
-    
+
     protected function checkConfig($config)
     {
         return $config['client_key_filename'] != null &&
@@ -14,26 +14,28 @@ class ZoiTest extends \PHPUnit_Framework_TestCase
     public function testGenerateZoi()
     {
         $config = include('_config.php');
-        
+
+        date_default_timezone_set($config['timezone'] ?: 'Europe/Ljubljana');
+
         if (!$this->checkConfig($config)) {
             $this->markTestSkipped('Config is empty');
             return;
         }
-        
+
         $fiscal_verification = new \Neonbug\FiscalVerification\FiscalVerification(
             $config['client_key_filename'],
             $config['client_key_password'],
             $config['ca_public_key_filename'],
             $config['base_url']
         );
-        
+
         $tax_number           = 12345678;
         $issue_date_time      = 1420070400; //1.1.2015 @ 0:00 (UTC)
         $business_premise_id  = 'premise1';
         $electronic_device_id = 'edevice1';
         $invoice_number       = '123';
         $invoice_amount       = 30.41123123;
-        
+
         $zoi = $fiscal_verification->generateZoi(
             $tax_number,
             $issue_date_time,
@@ -42,42 +44,42 @@ class ZoiTest extends \PHPUnit_Framework_TestCase
             $invoice_number,
             $invoice_amount
         );
-        
+
         $this->assertEquals($zoi, '1234567801.01.2015 01:00:00123premise1edevice130.41');
     }
-    
+
     public function testSignZoi()
     {
         $config = include('_config.php');
-        
+
         if (!$this->checkConfig($config)) {
             $this->markTestSkipped('Config is empty');
             return;
         }
-        
+
         $fiscal_verification = new \Neonbug\FiscalVerification\FiscalVerification(
             $config['client_key_filename'],
             $config['client_key_password'],
             $config['ca_public_key_filename'],
             $config['base_url']
         );
-        
+
         $test_zoi = '1234567801.01.2015 01:00:00123premise1edevice130.41';
         $signature = $fiscal_verification->signZoi(
             $test_zoi,
             false
         );
-        
+
         $ret = openssl_verify(
             $test_zoi,
             $signature,
             openssl_pkey_get_public(file_get_contents($config['client_key_filename'])),
             'sha256WithRSAEncryption'
         );
-        
+
         $this->assertEquals($ret, 1);
     }
-    
+
     /**
      * @expectedException              Exception
      * @expectedExceptionMessageRegExp #Error reading certs.*#
@@ -85,19 +87,19 @@ class ZoiTest extends \PHPUnit_Framework_TestCase
     public function testPrivateKeyReadFail()
     {
         $config = include('_config.php');
-        
+
         if (!$this->checkConfig($config)) {
             $this->markTestSkipped('Config is empty');
             return;
         }
-        
+
         $fiscal_verification = new \Neonbug\FiscalVerification\FiscalVerification(
             $config['client_key_filename'],
             'wrongpass',
             $config['ca_public_key_filename'],
             $config['base_url']
         );
-        
+
         $test_zoi = '1234567801.01.2015 01:00:00123premise1edevice130.41';
         $signature = $fiscal_verification->signZoi(
             $test_zoi,

--- a/tests/_config.php
+++ b/tests/_config.php
@@ -5,25 +5,25 @@ return array(
      * Example: __DIR__ . '/assets/test_certificate.pem'
      */
     'client_key_filename' => null,
-    
+
     /**
      * Password for unlocking client password
      * Example: 'password'
      */
     'client_key_password' => null,
-    
+
     /**
      * Full path to PEM-encoded public key
      * Example: __DIR__ . '/assets/sitest-ca.pem'
      */
     'ca_public_key_filename' => __DIR__ . '/assets/sitest-ca.pem',
-    
+
     /**
      * Base URL for FURS' JSON endpoint
      * Example: 'https://blagajne-test.fu.gov.si:9002'
      */
     'base_url' => 'https://blagajne-test.fu.gov.si:9002',
-    
+
     /**
      * Info from client certificate
      */
@@ -34,24 +34,30 @@ return array(
          * Example: '3943415972554603486'
          */
         'serial' => null,
-        
+
         /**
          * Complete issuer name
          * Example: 'C=SI, O=state-institutions, CN=Tax CA Test'
          */
         'issuer_name' => null,
-        
+
         /**
          * Complete subject name
          * Example: '/C=SI/O=state-institutions/OU=DavPotRacTEST/OU=10359320/serialNumber=1/CN=TESTNO PODJETJE 838'
          */
         'subject_name' => null
     ),
-    
+
     /**
      * Same tax number as in client certificate
      * Must be a number, not a string
      * Example: 12345678
      */
-    'tax_number' => null
+    'tax_number' => null,
+
+    /**
+     * Timezone we need to set for generating proper timestamps
+     * you need to set Timezone in which you live
+     */
+    'timezone' => 'Europe/Berlin'
 );


### PR DESCRIPTION
Removed package that was not used in this project, added extra setting for timezone. In some cases when your timezone is not properly set, test testGenerateZoi fails. Now timezone is defaulted to Europe/Ljubljana or whatever you set in config.